### PR TITLE
Updating name typo in II MIG post

### DIFF
--- a/_posts/2021-02-09-II-MIG-Cell-Established.md
+++ b/_posts/2021-02-09-II-MIG-Cell-Established.md
@@ -5,7 +5,7 @@ categories: [announcements, news]
 
 # II MIG Marine Coders Cell Established!
 
-#### The II MIG CO, Colonel Russel, signed the II MIG Marine Coder charter today effectively establishing the first Marine Coder Cell in the Fleet Marine Force.  
+#### The II MIG CO, Colonel Russell, signed the II MIG Marine Coder charter today effectively establishing the first Marine Coder Cell in the Fleet Marine Force.  
 
 Cells are a critical component to scaling the Marine Coder movement and connecting Marines in the fleet to tools, environments, training and resources championed by Marine Coders!   
 


### PR DESCRIPTION
Quick typo correction to the II MIG post. Correcting from 'Colonel Russel' to 'Colonel Russell.'