### PR TITLE
Create 404 Page

### DIFF
--- a/_pages/404.md
+++ b/_pages/404.md
@@ -1,0 +1,12 @@
+---
+title: "Page not Found"
+layout: splash
+permalink: /404
+---
+
+<br /><br />
+
+# Looks like you lost your way Marine.
+Forgot how to do land navigation?
+
+[Take me Home](/){: .btn .btn--inverse .btn--small}


### PR DESCRIPTION
## Summary
Introduce `_pages/404.md` that will replace Github Pages default 404 error page. Will close #106.

## Reference
![image](https://user-images.githubusercontent.com/30413278/176581100-2d050a9d-4b03-4983-b13c-4c026f7d9b0d.png)
